### PR TITLE
rate: avoid creating timer in WaitN if delay is zero

### DIFF
--- a/rate/rate.go
+++ b/rate/rate.go
@@ -253,8 +253,12 @@ func (lim *Limiter) waitN(ctx contextContext, n int) (err error) {
 	if !r.ok {
 		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", n)
 	}
-	// Wait
-	t := time.NewTimer(r.DelayFrom(now))
+	// Wait if necessary
+	delay := r.DelayFrom(now)
+	if delay == 0 {
+		return nil
+	}
+	t := time.NewTimer(delay)
 	defer t.Stop()
 	select {
 	case <-t.C:

--- a/rate/rate_test.go
+++ b/rate/rate_test.go
@@ -447,3 +447,13 @@ func BenchmarkAllowN(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkWaitNNoDelay(b *testing.B) {
+	lim := NewLimiter(Limit(b.N), b.N)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lim.WaitN(ctx, 1)
+	}
+}


### PR DESCRIPTION
name      old time/op    new time/op    delta
AllowN-4    76.7ns ± 6%    76.6ns ± 3%      ~     (p=0.897 n=10+10)
WaitNNoDelay-4     1.36µs ± 3%    0.10µs ± 1%   -92.64%  (p=0.000 n=10+9)

name      old alloc/op   new alloc/op   delta
AllowN-4     0.00B          0.00B           ~     (all equal)
WaitNNoDelay-4       208B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name      old allocs/op  new allocs/op  delta
AllowN-4      0.00           0.00           ~     (all equal)
WaitNNoDelay-4       3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)