### PR TITLE
rate: reduce allocation and speed up ReserveN

### DIFF
--- a/rate/rate.go
+++ b/rate/rate.go
@@ -189,7 +189,7 @@ func (r *Reservation) CancelAt(now time.Time) {
 }
 
 // Reserve is shorthand for ReserveN(time.Now(), 1).
-func (lim *Limiter) Reserve() *Reservation {
+func (lim *Limiter) Reserve() Reservation {
 	return lim.ReserveN(time.Now(), 1)
 }
 
@@ -207,9 +207,8 @@ func (lim *Limiter) Reserve() *Reservation {
 // Use this method if you wish to wait and slow down in accordance with the rate limit without dropping events.
 // If you need to respect a deadline or cancel the delay, use Wait instead.
 // To drop or skip events exceeding rate limit, use Allow instead.
-func (lim *Limiter) ReserveN(now time.Time, n int) *Reservation {
-	r := lim.reserveN(now, n, InfDuration)
-	return &r
+func (lim *Limiter) ReserveN(now time.Time, n int) Reservation {
+	return lim.reserveN(now, n, InfDuration)
 }
 
 // contextContext is a temporary(?) copy of the context.Context type

--- a/rate/rate_test.go
+++ b/rate/rate_test.go
@@ -457,3 +457,15 @@ func BenchmarkWaitNNoDelay(b *testing.B) {
 		lim.WaitN(ctx, 1)
 	}
 }
+
+func BenchmarkReserveN(b *testing.B) {
+	lim := NewLimiter(Every(1*time.Second), 1)
+	now := time.Now()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			lim.ReserveN(now, 1)
+		}
+	})
+}


### PR DESCRIPTION
benchmark               old ns/op     new ns/op     delta
BenchmarkReserveN-4     120           81.9          -31.75%

benchmark               old allocs     new allocs     delta
BenchmarkReserveN-4     1              0              -100.00%

benchmark               old bytes     new bytes     delta
BenchmarkReserveN-4     64            0             -100.00%