### PR TITLE
rate: fix truncated seconds in tokensFromDuration

### DIFF
--- a/rate/rate.go
+++ b/rate/rate.go
@@ -380,8 +380,8 @@ func (lim *Limiter) advance(now time.Time) (newNow time.Time, newLast time.Time,
 // durationFromTokens is a unit conversion function from the number of tokens to the duration
 // of time it takes to accumulate them at a rate of limit tokens per second.
 func (limit Limit) durationFromTokens(tokens float64) time.Duration {
-	seconds := tokens / float64(limit)
-	return time.Nanosecond * time.Duration(1e9*seconds)
+	nanosecond := (1e9 * tokens) / float64(limit)
+	return time.Nanosecond * time.Duration(nanosecond)
 }
 
 // tokensFromDuration is a unit conversion function from a time duration to the number of tokens

--- a/rate/rate_test.go
+++ b/rate/rate_test.go
@@ -447,7 +447,7 @@ func TestWaitInf(t *testing.T) {
 
 func TestIssue34861(t *testing.T) {
 	if !NewLimiter(Limit(0.7692307692307693), 1).Allow() {
-		t.Errorf("%v: expect true, got false", t.Name())
+		t.Error("expect true, got false")
 	}
 }
 

--- a/rate/rate_test.go
+++ b/rate/rate_test.go
@@ -445,6 +445,12 @@ func TestWaitInf(t *testing.T) {
 	runWait(t, lim, wait{"exceed-burst-no-error", context.Background(), 3, 0, true})
 }
 
+func TestIssue34861(t *testing.T) {
+	if !NewLimiter(Limit(0.7692307692307693), 1).Allow() {
+		t.Errorf("%v: expect true, got false", t.Name())
+	}
+}
+
 func BenchmarkAllowN(b *testing.B) {
 	lim := NewLimiter(Every(1*time.Second), 1)
 	now := time.Now()


### PR DESCRIPTION
This CL fixes a truncated variable which may cause an incorrect result.

Fix golang/go#34861