### PR TITLE
rate: simplify code

### DIFF
--- a/rate/rate.go
+++ b/rate/rate.go
@@ -364,15 +364,14 @@ func (lim *Limiter) advance(now time.Time) (newNow time.Time, newLast time.Time,
 		last = now
 	}
 
-	// Avoid making delta overflow below when last is very old.
-	maxElapsed := lim.limit.durationFromTokens(float64(lim.burst) - lim.tokens)
 	elapsed := now.Sub(last)
-	if elapsed > maxElapsed {
-		elapsed = maxElapsed
-	}
 
 	// Calculate the new number of tokens, due to time that passed.
 	delta := lim.limit.tokensFromDuration(elapsed)
+	// Avoid making delta overflow below when last is very old.
+	if max := float64(lim.burst) - lim.tokens; delta > max {
+		delta = max
+	}
 	tokens := lim.tokens + delta
 	if burst := float64(lim.burst); tokens > burst {
 		tokens = burst
@@ -385,15 +384,11 @@ func (lim *Limiter) advance(now time.Time) (newNow time.Time, newLast time.Time,
 // of time it takes to accumulate them at a rate of limit tokens per second.
 func (limit Limit) durationFromTokens(tokens float64) time.Duration {
 	seconds := tokens / float64(limit)
-	return time.Nanosecond * time.Duration(1e9*seconds)
+	return time.Duration(float64(time.Second) * seconds)
 }
 
 // tokensFromDuration is a unit conversion function from a time duration to the number of tokens
 // which could be accumulated during that duration at a rate of limit tokens per second.
 func (limit Limit) tokensFromDuration(d time.Duration) float64 {
-	// Split the integer and fractional parts ourself to minimize rounding errors.
-	// See golang.org/issues/34861.
-	sec := float64(d/time.Second) * float64(limit)
-	nsec := float64(d%time.Second) * float64(limit)
-	return sec + nsec/1e9
+	return d.Seconds() * float64(limit)
 }


### PR DESCRIPTION
When a long time has passed since a previous call to the rate limiter,
we can overflow when calculating how many new tokens are available.

To prevent that, we calculated a maximum elapsed amount.
When we used maxElapseed, we ended up converting a duration into tokens
and then back. This operation was lossy, so we took pains to increase
the precision of the conversion in tokensFromDuration.

An easier fix is to avoid the round trip entirely.
We know the max number of new tokens we should add; cap it directly.
This lets us use the original, simpler tokensFromDuration.

While we're here, tweak durationFromTokens for clarity.

Updates #34861
