### PR TITLE
rate: simplify function advance only returns new Tokens to caller

### DIFF
--- a/rate/rate.go
+++ b/rate/rate.go
@@ -380,7 +380,8 @@ func (lim *Limiter) reserveN(t time.Time, n int, maxFutureReserve time.Duration)
 	return r
 }
 
-// advance calculates and returns an updated state for lim resulting from the passage of time.
+// advance calculates and returns an updated number of tokens for lim
+// resulting from the passage of time.
 // lim is not changed.
 // advance requires that lim.mu is held.
 func (lim *Limiter) advance(t time.Time) (newTokens float64) {

--- a/rate/rate.go
+++ b/rate/rate.go
@@ -85,7 +85,7 @@ func (lim *Limiter) Burst() int {
 // TokensAt returns the number of tokens available at time t.
 func (lim *Limiter) TokensAt(t time.Time) float64 {
 	lim.mu.Lock()
-	_, tokens := lim.advance(t) // does not mutate lim
+	tokens := lim.advance(t) // does not mutate lim
 	lim.mu.Unlock()
 	return tokens
 }
@@ -186,7 +186,7 @@ func (r *Reservation) CancelAt(t time.Time) {
 		return
 	}
 	// advance time to now
-	t, tokens := r.lim.advance(t)
+	tokens := r.lim.advance(t)
 	// calculate new number of tokens
 	tokens += restoreTokens
 	if burst := float64(r.lim.burst); tokens > burst {
@@ -307,7 +307,7 @@ func (lim *Limiter) SetLimitAt(t time.Time, newLimit Limit) {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()
 
-	t, tokens := lim.advance(t)
+	tokens := lim.advance(t)
 
 	lim.last = t
 	lim.tokens = tokens
@@ -324,7 +324,7 @@ func (lim *Limiter) SetBurstAt(t time.Time, newBurst int) {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()
 
-	t, tokens := lim.advance(t)
+	tokens := lim.advance(t)
 
 	lim.last = t
 	lim.tokens = tokens
@@ -347,7 +347,7 @@ func (lim *Limiter) reserveN(t time.Time, n int, maxFutureReserve time.Duration)
 		}
 	}
 
-	t, tokens := lim.advance(t)
+	tokens := lim.advance(t)
 
 	// Calculate the remaining number of tokens resulting from the request.
 	tokens -= float64(n)
@@ -383,7 +383,7 @@ func (lim *Limiter) reserveN(t time.Time, n int, maxFutureReserve time.Duration)
 // advance calculates and returns an updated state for lim resulting from the passage of time.
 // lim is not changed.
 // advance requires that lim.mu is held.
-func (lim *Limiter) advance(t time.Time) (newT time.Time, newTokens float64) {
+func (lim *Limiter) advance(t time.Time) (newTokens float64) {
 	last := lim.last
 	if t.Before(last) {
 		last = t
@@ -396,7 +396,7 @@ func (lim *Limiter) advance(t time.Time) (newT time.Time, newTokens float64) {
 	if burst := float64(lim.burst); tokens > burst {
 		tokens = burst
 	}
-	return t, tokens
+	return tokens
 }
 
 // durationFromTokens is a unit conversion function from the number of tokens to the duration


### PR DESCRIPTION
Change the advance method to stop returning the newT result,
because it is always the same as the t argument.